### PR TITLE
Update BUILD

### DIFF
--- a/tensorflow/contrib/image/BUILD
+++ b/tensorflow/contrib/image/BUILD
@@ -105,6 +105,9 @@ tf_custom_op_library(
         "kernels/single_image_random_dot_stereograms_ops.cc",
         "ops/single_image_random_dot_stereograms_ops.cc",
     ],
+    deps = [
+        "@protobuf//:protobuf",
+    ],
 )
 
 tf_gen_op_libs(


### PR DESCRIPTION
fix issues/421
the problem reason is single_image_random_dot_stereograms.cc<<kernels>> be dependent on TensorShapeProto
it define on protobuf, use class LogMessage. but no deps protobuf on BUILD rule python/ops/_single_image_random_dot_stereograms.so .
so Symbol not found: __ZN6google8protobuf8internal10LogMessageC1ENS0_8LogLevelEPKci(google::protobuf::internal::LogMessage::LogMessage)